### PR TITLE
fix: renovate rangeStrategy: bump

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "rangeStrategy": "bump", // ensure the version in package.json gets bumped (e.g. ^1.0.0 -> ^1.1.0)
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
Fix renovate config to use `"rangeStrategy": "bump"`. This will start bumping the package.json versions as well as package-lock. Ref: https://docs.renovatebot.com/configuration-options/#rangestrategy.